### PR TITLE
added note about how to access external directories from the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ inside it. Here are the steps for that.
    to kick off the spike ISA simulator on a root filesystem awith
    busybox nd the 3.14.41 version of the Linux kernel.
 
+   5. You can attach external directories for access inside the docker
+   container:
+
+```
+   docker run -it -w $PWD -v $PWD:$PWD sbates130272/riscv
+```
+
 ### Notes
 
    1. Note this Dockerfile does not run through the automated build


### PR DESCRIPTION
Sometimes it is useful to be able to use external files from the container. This commit adds a note about how to attach a directory as a volume in the container and how to set the working directory of the shell started in the container.
